### PR TITLE
updates to allow for event_trigger in cloudfunctions function.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -41,10 +41,6 @@ resource "google_pubsub_subscription" "event_subscription" {
   topic = google_pubsub_topic.event_topic.name
 
   depends_on = [google_pubsub_topic.event_topic]
-
-  push_config {
-    push_endpoint = google_cloudfunctions2_function.handler_function.https_trigger_url
-  }
 }
 
 resource "google_storage_bucket" "handler_storage_bucket" {


### PR DESCRIPTION
cloudfunctions version 2 https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudfunctions2_function allows for event_trigger config from pubsub.